### PR TITLE
NGワード追加時、過去のNGワードに対する削除をなくす

### DIFF
--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -371,27 +370,25 @@ func moderateHandler(c echo.Context) error {
 	}
 
 	// 今回追加されたNGワードにヒットする過去の投稿を削除する
-	// (1) コメント全件取得
 	var livecomments []*LivecommentModel
 	if err := tx.SelectContext(ctx, &livecomments, "SELECT * FROM livecomments WHERE livestream_id = ?", livestreamID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livecomments: "+err.Error())
 	}
 
-	// (2) NGワード含むものを抽出
-	var targetIDs []int64
 	for _, livecomment := range livecomments {
-		if strings.Contains(livecomment.Comment, req.NGWord) {
-			targetIDs = append(targetIDs, livecomment.ID)
-		}
-	}
-
-	// (3) DELETE
-	if len(targetIDs) > 0 {
-		query, args, err := sqlx.In("DELETE FROM livecomments WHERE id IN (?)", targetIDs)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to build delete query: "+err.Error())
-		}
-		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		query := `
+		DELETE FROM livecomments
+		WHERE
+		id = ? AND
+		livestream_id = ? AND
+		(SELECT COUNT(*)
+		FROM
+		(SELECT ? AS text) AS texts
+		INNER JOIN
+		(SELECT CONCAT('%', ?, '%')	AS pattern) AS patterns
+		ON texts.text LIKE patterns.pattern) >= 1;
+		`
+		if _, err := tx.ExecContext(ctx, query, livecomment.ID, livestreamID, livecomment.Comment, req.NGWord); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
 		}
 	}


### PR DESCRIPTION
refs #1 

NGワード追加の都度合致する投稿を消しているなら、過去のNGワードを含む削除済みなので無視して良いはず

slow query 2位

```
# Query 2: 139.94 QPS, 0.11x concurrency, ID 0x4ADE2DC90689F1C4891749AF54FB8D14 at byte 207099204
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2026-01-12T02:43:04 to 2026-01-12T02:58:45
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          8  131683
# Exec time     10    107s   101us    57ms   813us     3ms     2ms   194us
# Lock time      8   475ms       0     8ms     3us     1us    82us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0 257.24k       2       4    2.00    1.96    0.03    1.96
# Query size    15  41.53M     263     526  330.69  363.48   27.60  313.99
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  ################################################################
#   1ms  ###############
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livecomments'\G
#    SHOW CREATE TABLE `isupipe`.`livecomments`\G
DELETE FROM livecomments
            WHERE
            id = 746 AND
            livestream_id = 7537 AND
            (SELECT COUNT(*)
            FROM
            (SELECT '朝から元気になれる配信ありがとう！' AS text) AS texts
            INNER JOIN
            (SELECT CONCAT('%', '攣合', '%')    AS pattern) AS patterns
            ON texts.text LIKE patterns.pattern) >= 1\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select * from  livecomments
            WHERE
            id = 746 AND
            livestream_id = 7537 AND
            (SELECT COUNT(*)
            FROM
            (SELECT '朝から元気になれる配信ありがとう！' AS text) AS texts
            INNER JOIN
            (SELECT CONCAT('%', '攣合', '%')    AS pattern) AS patterns
            ON texts.text LIKE patterns.pattern) >= 1\G
```