### PR TITLE
アイコン画像のファイルシステムキャッシュを実装

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -113,6 +113,12 @@ func initializeHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to initialize: "+err.Error())
 	}
 
+	// アイコンキャッシュをクリア
+	if err := clearIconCache(); err != nil {
+		c.Logger().Warnf("failed to clear icon cache: %v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to initialize: "+err.Error())
+	}
+
 	// 追加
 	go func() {
 		if _, err := http.Get("http://18.181.252.154:9000/api/group/collect"); err != nil {
@@ -208,6 +214,12 @@ func main() {
 		os.Exit(1)
 	}
 	powerDNSSubdomainAddress = subdomainAddr
+
+	// アイコンキャッシュを初期化
+	if err := initIconCache(); err != nil {
+		e.Logger.Errorf("failed to initialize icon cache: %v", err)
+		os.Exit(1)
+	}
 
 	// HTTPサーバ起動
 	listenAddr := net.JoinHostPort("", strconv.Itoa(listenPort))

--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -29,6 +30,74 @@ const (
 )
 
 var fallbackImage = "../img/NoImage.jpg"
+
+// アイコンキャッシュ用ディレクトリ
+var iconCacheDir = "../icons"
+
+// アイコンハッシュのメモリキャッシュ
+var (
+	iconHashCache   = make(map[int64]string)
+	iconHashCacheMu sync.RWMutex
+)
+
+// fallback 画像のハッシュ（起動時に計算）
+var fallbackImageHash string
+
+func initIconCache() error {
+	// キャッシュディレクトリを作成
+	if err := os.MkdirAll(iconCacheDir, 0755); err != nil {
+		return err
+	}
+
+	// fallback 画像のハッシュを計算
+	fallbackImageData, err := os.ReadFile(fallbackImage)
+	if err != nil {
+		return err
+	}
+	hash := sha256.Sum256(fallbackImageData)
+	fallbackImageHash = fmt.Sprintf("%x", hash)
+
+	return nil
+}
+
+func clearIconCache() error {
+	// メモリキャッシュをクリア
+	iconHashCacheMu.Lock()
+	iconHashCache = make(map[int64]string)
+	iconHashCacheMu.Unlock()
+
+	// キャッシュディレクトリ内のファイルを削除
+	entries, err := os.ReadDir(iconCacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.MkdirAll(iconCacheDir, 0755)
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			os.Remove(fmt.Sprintf("%s/%s", iconCacheDir, entry.Name()))
+		}
+	}
+	return nil
+}
+
+func getIconPath(userID int64) string {
+	return fmt.Sprintf("%s/%d.jpg", iconCacheDir, userID)
+}
+
+func getIconHash(userID int64) (string, bool) {
+	iconHashCacheMu.RLock()
+	hash, ok := iconHashCache[userID]
+	iconHashCacheMu.RUnlock()
+	return hash, ok
+}
+
+func setIconHash(userID int64, hash string) {
+	iconHashCacheMu.Lock()
+	iconHashCache[userID] = hash
+	iconHashCacheMu.Unlock()
+}
 
 type UserModel struct {
 	ID             int64  `db:"id"`
@@ -104,6 +173,14 @@ func getIconHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get user: "+err.Error())
 	}
 
+	// ファイルシステムからアイコンを読み込む
+	iconPath := getIconPath(user.ID)
+	if _, err := os.Stat(iconPath); err == nil {
+		// ファイルが存在する場合
+		return c.File(iconPath)
+	}
+
+	// ファイルが存在しない場合は DB から取得してキャッシュ
 	var image []byte
 	if err := tx.GetContext(ctx, &image, "SELECT image FROM icons WHERE user_id = ?", user.ID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -112,6 +189,16 @@ func getIconHandler(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get user icon: "+err.Error())
 		}
 	}
+
+	// ファイルに保存（キャッシュ）
+	if err := os.WriteFile(iconPath, image, 0644); err != nil {
+		// 書き込み失敗してもレスポンスは返す
+		c.Logger().Warnf("failed to cache icon: %v", err)
+	}
+
+	// ハッシュも計算してキャッシュ
+	hash := sha256.Sum256(image)
+	setIconHash(user.ID, fmt.Sprintf("%x", hash))
 
 	return c.Blob(http.StatusOK, "image/jpeg", image)
 }
@@ -157,6 +244,16 @@ func postIconHandler(c echo.Context) error {
 	if err := tx.Commit(); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
 	}
+
+	// ファイルシステムにも保存（キャッシュ）
+	iconPath := getIconPath(userID)
+	if err := os.WriteFile(iconPath, req.Image, 0644); err != nil {
+		c.Logger().Warnf("failed to cache icon: %v", err)
+	}
+
+	// ハッシュを計算してメモリキャッシュに保存
+	hash := sha256.Sum256(req.Image)
+	setIconHash(userID, fmt.Sprintf("%x", hash))
 
 	return c.JSON(http.StatusCreated, &PostIconResponse{
 		ID: iconID,
@@ -437,35 +534,60 @@ func fillUsersResponse(ctx context.Context, tx *sqlx.Tx, userModels []UserModel)
 		themeMap[t.UserID] = t
 	}
 
-	// icons を一括取得
-	query, args, err = sqlx.In("SELECT user_id, image FROM icons WHERE user_id IN (?)", userIDs)
-	if err != nil {
-		return nil, err
-	}
-	var iconModels []IconModel
-	if err := tx.SelectContext(ctx, &iconModels, query, args...); err != nil {
-		return nil, err
-	}
-	iconMap := make(map[int64][]byte)
-	for _, icon := range iconModels {
-		iconMap[icon.UserID] = icon.Image
+	// メモリキャッシュにないユーザーIDを収集
+	var uncachedUserIDs []int64
+	iconHashMap := make(map[int64]string)
+	for _, userID := range userIDs {
+		if hash, ok := getIconHash(userID); ok {
+			iconHashMap[userID] = hash
+		} else {
+			uncachedUserIDs = append(uncachedUserIDs, userID)
+		}
 	}
 
-	// fallback 画像を読み込み（アイコンがないユーザー用）
-	fallbackImageData, err := os.ReadFile(fallbackImage)
-	if err != nil {
-		return nil, err
+	// キャッシュにないユーザーのアイコンのみDBから取得
+	if len(uncachedUserIDs) > 0 {
+		query, args, err = sqlx.In("SELECT user_id, image FROM icons WHERE user_id IN (?)", uncachedUserIDs)
+		if err != nil {
+			return nil, err
+		}
+		var iconModels []IconModel
+		if err := tx.SelectContext(ctx, &iconModels, query, args...); err != nil {
+			return nil, err
+		}
+
+		// アイコンがあるユーザーのハッシュを計算してキャッシュ
+		iconUserIDSet := make(map[int64]struct{})
+		for _, icon := range iconModels {
+			hash := sha256.Sum256(icon.Image)
+			hashStr := fmt.Sprintf("%x", hash)
+			iconHashMap[icon.UserID] = hashStr
+			setIconHash(icon.UserID, hashStr)
+			iconUserIDSet[icon.UserID] = struct{}{}
+
+			// ファイルにも保存
+			iconPath := getIconPath(icon.UserID)
+			if _, err := os.Stat(iconPath); os.IsNotExist(err) {
+				os.WriteFile(iconPath, icon.Image, 0644)
+			}
+		}
+
+		// アイコンがないユーザーは fallback ハッシュを使用
+		for _, userID := range uncachedUserIDs {
+			if _, ok := iconUserIDSet[userID]; !ok {
+				iconHashMap[userID] = fallbackImageHash
+			}
+		}
 	}
 
 	// User を構築
 	users := make([]User, len(userModels))
 	for i, userModel := range userModels {
 		theme := themeMap[userModel.ID]
-		image, ok := iconMap[userModel.ID]
-		if !ok {
-			image = fallbackImageData
+		iconHash := iconHashMap[userModel.ID]
+		if iconHash == "" {
+			iconHash = fallbackImageHash
 		}
-		iconHash := sha256.Sum256(image)
 
 		users[i] = User{
 			ID:          userModel.ID,
@@ -476,7 +598,7 @@ func fillUsersResponse(ctx context.Context, tx *sqlx.Tx, userModels []UserModel)
 				ID:       theme.ID,
 				DarkMode: theme.DarkMode,
 			},
-			IconHash: fmt.Sprintf("%x", iconHash),
+			IconHash: iconHash,
 		}
 	}
 


### PR DESCRIPTION
refs #1

アイコン画像の読み込み時にDBアクセスを減らすため、ファイルシステムと
メモリの2層キャッシュを導入。

- getIconHandler: ファイルシステムを先にチェックし、なければDBから取得してキャッシュ
- postIconHandler: DBコミット後にファイルシステムにも保存
- fillUsersResponse: メモリキャッシュからハッシュを取得、キャッシュミス時のみDBアクセス
- initializeHandler: キャッシュクリア処理を追加
- main: 起動時にキャッシュ初期化