### PR TITLE
feat: Stats ランキング集計に singleflight を導入

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -137,6 +137,8 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go/stats_handler.go
+++ b/go/stats_handler.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/labstack/echo/v4"
+	"golang.org/x/sync/singleflight"
 )
 
 type LivestreamStatistics struct {
@@ -66,6 +67,11 @@ type UserScoreEntry struct {
 	Score    int64  `db:"score"`
 }
 
+var (
+	userRankingSF       singleflight.Group
+	livestreamRankingSF singleflight.Group
+)
+
 func getUserStatisticsHandler(c echo.Context) error {
 	ctx := c.Request().Context()
 
@@ -93,40 +99,46 @@ func getUserStatisticsHandler(c echo.Context) error {
 		}
 	}
 
-	// ランク算出: 全ユーザーのスコア（リアクション数 + チップ合計）を一括取得
-	var userScores []UserScoreEntry
-	rankQuery := `
-		SELECT
-			u.id AS user_id,
-			u.name AS username,
-			IFNULL(SUM(r.reaction_count), 0) + IFNULL(SUM(lc.tip_sum), 0) AS score
-		FROM users u
-		LEFT JOIN livestreams l ON l.user_id = u.id
-		LEFT JOIN (
-			SELECT livestream_id, COUNT(*) AS reaction_count
-			FROM reactions
-			GROUP BY livestream_id
-		) r ON r.livestream_id = l.id
-		LEFT JOIN (
-			SELECT livestream_id, SUM(tip) AS tip_sum
-			FROM livecomments
-			GROUP BY livestream_id
-		) lc ON lc.livestream_id = l.id
-		GROUP BY u.id, u.name
-	`
-	if err := tx.SelectContext(ctx, &userScores, rankQuery); err != nil {
+	// ランク算出: 全ユーザーのスコアを singleflight で一括取得（同時リクエストで共有）
+	rankingResult, err, _ := userRankingSF.Do("ranking", func() (interface{}, error) {
+		var scores []UserScoreEntry
+		rankQuery := `
+			SELECT
+				u.id AS user_id,
+				u.name AS username,
+				IFNULL(SUM(r.reaction_count), 0) + IFNULL(SUM(lc.tip_sum), 0) AS score
+			FROM users u
+			LEFT JOIN livestreams l ON l.user_id = u.id
+			LEFT JOIN (
+				SELECT livestream_id, COUNT(*) AS reaction_count
+				FROM reactions
+				GROUP BY livestream_id
+			) r ON r.livestream_id = l.id
+			LEFT JOIN (
+				SELECT livestream_id, SUM(tip) AS tip_sum
+				FROM livecomments
+				GROUP BY livestream_id
+			) lc ON lc.livestream_id = l.id
+			GROUP BY u.id, u.name
+		`
+		if err := dbConn.SelectContext(ctx, &scores, rankQuery); err != nil {
+			return nil, err
+		}
+
+		var ranking UserRanking
+		for _, us := range scores {
+			ranking = append(ranking, UserRankingEntry{
+				Username: us.Username,
+				Score:    us.Score,
+			})
+		}
+		sort.Sort(ranking)
+		return ranking, nil
+	})
+	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get user scores: "+err.Error())
 	}
-
-	// ランキングをソート
-	var ranking UserRanking
-	for _, us := range userScores {
-		ranking = append(ranking, UserRankingEntry{
-			Username: us.Username,
-			Score:    us.Score,
-		})
-	}
-	sort.Sort(ranking)
+	ranking := rankingResult.(UserRanking)
 
 	var rank int64 = 1
 	for i := len(ranking) - 1; i >= 0; i-- {
@@ -233,37 +245,43 @@ func getLivestreamStatisticsHandler(c echo.Context) error {
 		}
 	}
 
-	// ランク算出: 全ライブストリームのスコア（リアクション数 + チップ合計）を一括取得
-	var livestreamScores []LivestreamScoreEntry
-	rankQuery := `
-		SELECT
-			l.id AS livestream_id,
-			IFNULL(r.reaction_count, 0) + IFNULL(lc.tip_sum, 0) AS score
-		FROM livestreams l
-		LEFT JOIN (
-			SELECT livestream_id, COUNT(*) AS reaction_count
-			FROM reactions
-			GROUP BY livestream_id
-		) r ON r.livestream_id = l.id
-		LEFT JOIN (
-			SELECT livestream_id, SUM(tip) AS tip_sum
-			FROM livecomments
-			GROUP BY livestream_id
-		) lc ON lc.livestream_id = l.id
-	`
-	if err := tx.SelectContext(ctx, &livestreamScores, rankQuery); err != nil {
+	// ランク算出: 全ライブストリームのスコアを singleflight で一括取得（同時リクエストで共有）
+	rankingResult, err, _ := livestreamRankingSF.Do("ranking", func() (interface{}, error) {
+		var scores []LivestreamScoreEntry
+		rankQuery := `
+			SELECT
+				l.id AS livestream_id,
+				IFNULL(r.reaction_count, 0) + IFNULL(lc.tip_sum, 0) AS score
+			FROM livestreams l
+			LEFT JOIN (
+				SELECT livestream_id, COUNT(*) AS reaction_count
+				FROM reactions
+				GROUP BY livestream_id
+			) r ON r.livestream_id = l.id
+			LEFT JOIN (
+				SELECT livestream_id, SUM(tip) AS tip_sum
+				FROM livecomments
+				GROUP BY livestream_id
+			) lc ON lc.livestream_id = l.id
+		`
+		if err := dbConn.SelectContext(ctx, &scores, rankQuery); err != nil {
+			return nil, err
+		}
+
+		var ranking LivestreamRanking
+		for _, ls := range scores {
+			ranking = append(ranking, LivestreamRankingEntry{
+				LivestreamID: ls.LivestreamID,
+				Score:        ls.Score,
+			})
+		}
+		sort.Sort(ranking)
+		return ranking, nil
+	})
+	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livestream scores: "+err.Error())
 	}
-
-	// ランキングをソート
-	var ranking LivestreamRanking
-	for _, ls := range livestreamScores {
-		ranking = append(ranking, LivestreamRankingEntry{
-			LivestreamID: ls.LivestreamID,
-			Score:        ls.Score,
-		})
-	}
-	sort.Sort(ranking)
+	ranking := rankingResult.(LivestreamRanking)
 
 	var rank int64 = 1
 	for i := len(ranking) - 1; i >= 0; i-- {


### PR DESCRIPTION
#27

## Summary
- ユーザーランキングとライブストリームランキングの集計クエリに `singleflight` パターンを導入
- 同時リクエスト時に重い GROUP BY クエリ（ユーザー: Sum 4.85s / ライブストリーム: Sum 2.99s）を1回の DB 実行で共有
- ランキングクエリはトランザクション外（`dbConn` 直接）に変更（singleflight コールバック内でトランザクションを共有できないため）

## Test plan
- [x] `make gogo` でビルド・デプロイが通ることを確認
- [x] ベンチマークを実行し、スコアが下がらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)